### PR TITLE
Rh-mariadb105 conflict with mysqld service

### DIFF
--- a/nethserver-rh-mariadb105.spec
+++ b/nethserver-rh-mariadb105.spec
@@ -19,12 +19,15 @@ NethServer MariaDB 10.5 configuration
 %setup
 
 %build
+%{__mkdir} -p root/var/log/rh-mariadb105
 perl createlinks
 
 %install
 rm -rf %{buildroot}
 (cd root; find . -depth -print | cpio -dump %{buildroot})
-%{genfilelist} %{buildroot} > %{name}-%{version}-filelist
+%{genfilelist} \
+    --dir   /var/log/rh-mariadb105 'attr(0755,mysql,mysql)' \
+%{buildroot} > %{name}-%{version}-filelist
 
 %post
 

--- a/root/etc/systemd/system/rh-mariadb105-mariadb.service
+++ b/root/etc/systemd/system/rh-mariadb105-mariadb.service
@@ -1,28 +1,7 @@
-# It's not recommended to modify this file in-place, because it will be
-# overwritten during package upgrades.  If you want to customize, the
-# best way is to create a file "/etc/systemd/system/rh-mariadb105-mariadb.service",
-# containing
-#	.include /usr/lib/systemd/system/rh-mariadb105-mariadb.service
-#	...make your changes here...
-# or create a file "/etc/systemd/system/rh-mariadb105-mariadb.service.d/foo.conf",
-# which doesn't need to include ".include" call and which will be parsed
-# after the file rh-mariadb105-mariadb.service itself is parsed.
-#
-# For more info about custom unit files, see systemd.unit(5) or
-# http://fedoraproject.org/wiki/Systemd#How_do_I_customize_a_unit_file.2F_add_a_custom_unit_file.3F
-
-# For example, if you want to increase mysql's open-files-limit to 10000,
-# you need to increase systemd's LimitNOFILE setting, so create a file named
-# "/etc/systemd/system/rh-mariadb105-mariadb.service.d/limits.conf" containing:
-#	[Service]
-#	LimitNOFILE=10000
-
-# Note: /usr/lib/... is recommended in the .include line though /lib/...
-# still works.
-# Don't forget to reload systemd daemon after you change unit configuration:
-# root> systemctl --system daemon-reload
-
-# Use [mysqld.INSTANCENAME] as sections in my.cnf to configure this instance.
+# NethServer replaces original systemd unit to avoid conflicts with nethserver-mysql
+# This file disabled unit name aliasing:
+#   Alias=mysql.service
+#  Alias=mysqld.service
 
 [Unit]
 Description=MariaDB 10.5 database server

--- a/root/etc/systemd/system/rh-mariadb105-mariadb.service
+++ b/root/etc/systemd/system/rh-mariadb105-mariadb.service
@@ -1,6 +1,6 @@
 # NethServer replaces original systemd unit to avoid conflicts with nethserver-mysql
 # This file disabled unit name aliasing:
-#   Alias=mysql.service
+#  Alias=mysql.service
 #  Alias=mysqld.service
 
 [Unit]
@@ -11,9 +11,6 @@ After=network.target
 
 [Install]
 WantedBy=multi-user.target
-# we must comment it because we use mysqld as alias for mariadb
-#Alias=mysql.service
-#Alias=mysqld.service
 
 [Service]
 Type=notify

--- a/root/etc/systemd/system/rh-mariadb105-mariadb.service
+++ b/root/etc/systemd/system/rh-mariadb105-mariadb.service
@@ -1,0 +1,80 @@
+# It's not recommended to modify this file in-place, because it will be
+# overwritten during package upgrades.  If you want to customize, the
+# best way is to create a file "/etc/systemd/system/rh-mariadb105-mariadb.service",
+# containing
+#	.include /usr/lib/systemd/system/rh-mariadb105-mariadb.service
+#	...make your changes here...
+# or create a file "/etc/systemd/system/rh-mariadb105-mariadb.service.d/foo.conf",
+# which doesn't need to include ".include" call and which will be parsed
+# after the file rh-mariadb105-mariadb.service itself is parsed.
+#
+# For more info about custom unit files, see systemd.unit(5) or
+# http://fedoraproject.org/wiki/Systemd#How_do_I_customize_a_unit_file.2F_add_a_custom_unit_file.3F
+
+# For example, if you want to increase mysql's open-files-limit to 10000,
+# you need to increase systemd's LimitNOFILE setting, so create a file named
+# "/etc/systemd/system/rh-mariadb105-mariadb.service.d/limits.conf" containing:
+#	[Service]
+#	LimitNOFILE=10000
+
+# Note: /usr/lib/... is recommended in the .include line though /lib/...
+# still works.
+# Don't forget to reload systemd daemon after you change unit configuration:
+# root> systemctl --system daemon-reload
+
+# Use [mysqld.INSTANCENAME] as sections in my.cnf to configure this instance.
+
+[Unit]
+Description=MariaDB 10.5 database server
+Documentation=man:mysqld(8)
+Documentation=https://mariadb.com/kb/en/library/systemd/
+After=network.target
+
+[Install]
+WantedBy=multi-user.target
+# we must comment it because we use mysqld as alias for mariadb
+#Alias=mysql.service
+#Alias=mysqld.service
+
+[Service]
+Type=notify
+User=mysql
+Group=mysql
+
+# Load collections set to enabled for this service
+EnvironmentFile=/opt/rh/rh-mariadb105/service-environment
+
+# We want to start server only inside "scl enable" invocation
+ExecStartPre=/usr/bin/scl enable $RH_MARIADB105_SCLS_ENABLED -- /usr/bin/scl_enabled rh-mariadb105
+
+ExecStartPre=/usr/bin/scl enable $RH_MARIADB105_SCLS_ENABLED -- /opt/rh/rh-mariadb105/root/usr/libexec/mysql-check-socket
+# '%n' expands to 'Full unit name'; man systemd.unit
+ExecStartPre=/usr/bin/scl enable $RH_MARIADB105_SCLS_ENABLED -- /opt/rh/rh-mariadb105/root/usr/libexec/mysql-prepare-db-dir %n
+# MYSQLD_OPTS here is for users to set in /etc/systemd/system/rh-mariadb105-mariadb@.service.d/MY_SPECIAL.conf
+# Note: we set --basedir to prevent probes that might trigger SELinux alarms,
+# per bug #547485
+ExecStart=/opt/rh/rh-mariadb105/root/usr/libexec/mysqld-scl-helper enable $RH_MARIADB105_SCLS_ENABLED -- /opt/rh/rh-mariadb105/root/usr/libexec/mysqld --basedir=/opt/rh/rh-mariadb105/root/usr $MYSQLD_OPTS $_WSREP_NEW_CLUSTER
+ExecStartPost=/usr/bin/scl enable $RH_MARIADB105_SCLS_ENABLED -- /opt/rh/rh-mariadb105/root/usr/libexec/mysql-check-upgrade
+
+# Setting this to true can break replication and the Type=notify settings
+# See also bind-address mysqld option.
+PrivateNetwork=false
+
+KillMode=process
+KillSignal=SIGTERM
+
+# Don't want to see an automated SIGKILL ever
+SendSIGKILL=no
+
+# Restart crashed server only, on-failure would also restart, for example, when
+# my.cnf contains unknown option
+Restart=on-abort
+RestartSec=5s
+
+UMask=007
+
+# Give a reasonable amount of time for the server to start up/shut down
+TimeoutSec=300
+
+# Place temp files in a secure directory, not /tmp
+PrivateTmp=true

--- a/root/etc/systemd/system/rh-mariadb105-mariadb@.service
+++ b/root/etc/systemd/system/rh-mariadb105-mariadb@.service
@@ -1,0 +1,86 @@
+# Multi instance version of mariadb. For if you run mutiple verions at once.
+# Also used for rh-mariadb105-mariadb@bootstrap to bootstrap Galera.
+#
+# To use multi instance variant, use [mysqld.INSTANCENAME] as sections in my.cnf
+# and start the service via:
+#	systemctl start rh-mariadb105-mariadb@{instancename}.server
+#
+# It's not recommended to modify this file in-place, because it will be
+# overwritten during package upgrades.  If you want to customize, the
+# best way is to create a file "/etc/systemd/system/rh-mariadb105-mariadb.service",
+# containing
+#	.include /usr/lib/systemd/system/rh-mariadb105-mariadb.service
+#	...make your changes here...
+# or create a file "/etc/systemd/system/rh-mariadb105-mariadb.service.d/foo.conf",
+# which doesn't need to include ".include" call and which will be parsed
+# after the file rh-mariadb105-mariadb.service itself is parsed.
+#
+# For more info about custom unit files, see systemd.unit(5) or
+# http://fedoraproject.org/wiki/Systemd#How_do_I_customize_a_unit_file.2F_add_a_custom_unit_file.3F
+
+# For example, if you want to increase mysql's open-files-limit to 10000,
+# you need to increase systemd's LimitNOFILE setting, so create a file named
+# "/etc/systemd/system/rh-mariadb105-mariadb.service.d/limits.conf" containing:
+#	[Service]
+#	LimitNOFILE=10000
+
+# Note: /usr/lib/... is recommended in the .include line though /lib/...
+# still works.
+# Don't forget to reload systemd daemon after you change unit configuration:
+# root> systemctl --system daemon-reload
+
+# Use [mysqld.INSTANCENAME] as sections in my.cnf to configure this instance.
+
+[Unit]
+Description=MariaDB 10.5 database server
+Documentation=man:mysqld(8)
+Documentation=https://mariadb.com/kb/en/library/systemd/
+After=network.target
+
+[Install]
+WantedBy=multi-user.target
+# we must comment it because we use mysqld as alias for mariadb
+#Alias=mysql.service
+#Alias=mysqld.service
+
+[Service]
+Type=notify
+User=mysql
+Group=mysql
+
+# Load collections set to enabled for this service
+EnvironmentFile=/opt/rh/rh-mariadb105/service-environment
+
+# We want to start server only inside "scl enable" invocation
+ExecStartPre=/usr/bin/scl enable $RH_MARIADB105_SCLS_ENABLED -- /usr/bin/scl_enabled rh-mariadb105
+
+ExecStartPre=/usr/bin/scl enable $RH_MARIADB105_SCLS_ENABLED -- /opt/rh/rh-mariadb105/root/usr/libexec/mysql-check-socket --defaults-group-suffix=.%I
+ExecStartPre=/usr/bin/scl enable $RH_MARIADB105_SCLS_ENABLED -- /opt/rh/rh-mariadb105/root/usr/libexec/mysql-prepare-db-dir --defaults-group-suffix=.%I %n
+# MYSQLD_OPTS here is for users to set in /etc/systemd/system/rh-mariadb105-mariadb@.service.d/MY_SPECIAL.conf
+# Note: we set --basedir to prevent probes that might trigger SELinux alarms,
+# per bug #547485
+ExecStart=/opt/rh/rh-mariadb105/root/usr/libexec/mysqld-scl-helper enable $RH_MARIADB105_SCLS_ENABLED -- /opt/rh/rh-mariadb105/root/usr/libexec/mysqld --defaults-group-suffix=.%I --basedir=/opt/rh/rh-mariadb105/root/usr $MYSQLD_OPTS $_WSREP_NEW_CLUSTER
+ExecStartPost=/usr/bin/scl enable $RH_MARIADB105_SCLS_ENABLED -- /opt/rh/rh-mariadb105/root/usr/libexec/mysql-check-upgrade --defaults-group-suffix=.%I
+
+# Setting this to true can break replication and the Type=notify settings
+# See also bind-address mysqld option.
+PrivateNetwork=false
+
+KillMode=process
+KillSignal=SIGTERM
+
+# Don't want to see an automated SIGKILL ever
+SendSIGKILL=no
+
+# Restart crashed server only, on-failure would also restart, for example, when
+# my.cnf contains unknown option
+Restart=on-abort
+RestartSec=5s
+
+UMask=007
+
+# Give a reasonable amount of time for the server to start up/shut down
+TimeoutSec=300
+
+# Place temp files in a secure directory, not /tmp
+PrivateTmp=true

--- a/root/etc/systemd/system/rh-mariadb105-mariadb@.service
+++ b/root/etc/systemd/system/rh-mariadb105-mariadb@.service
@@ -1,35 +1,7 @@
-# Multi instance version of mariadb. For if you run mutiple verions at once.
-# Also used for rh-mariadb105-mariadb@bootstrap to bootstrap Galera.
-#
-# To use multi instance variant, use [mysqld.INSTANCENAME] as sections in my.cnf
-# and start the service via:
-#	systemctl start rh-mariadb105-mariadb@{instancename}.server
-#
-# It's not recommended to modify this file in-place, because it will be
-# overwritten during package upgrades.  If you want to customize, the
-# best way is to create a file "/etc/systemd/system/rh-mariadb105-mariadb.service",
-# containing
-#	.include /usr/lib/systemd/system/rh-mariadb105-mariadb.service
-#	...make your changes here...
-# or create a file "/etc/systemd/system/rh-mariadb105-mariadb.service.d/foo.conf",
-# which doesn't need to include ".include" call and which will be parsed
-# after the file rh-mariadb105-mariadb.service itself is parsed.
-#
-# For more info about custom unit files, see systemd.unit(5) or
-# http://fedoraproject.org/wiki/Systemd#How_do_I_customize_a_unit_file.2F_add_a_custom_unit_file.3F
-
-# For example, if you want to increase mysql's open-files-limit to 10000,
-# you need to increase systemd's LimitNOFILE setting, so create a file named
-# "/etc/systemd/system/rh-mariadb105-mariadb.service.d/limits.conf" containing:
-#	[Service]
-#	LimitNOFILE=10000
-
-# Note: /usr/lib/... is recommended in the .include line though /lib/...
-# still works.
-# Don't forget to reload systemd daemon after you change unit configuration:
-# root> systemctl --system daemon-reload
-
-# Use [mysqld.INSTANCENAME] as sections in my.cnf to configure this instance.
+# NethServer replaces original systemd unit to avoid conflicts with nethserver-mysql
+# This file disabled unit name aliasing:
+#  Alias=mysql.service
+#  Alias=mysqld.service
 
 [Unit]
 Description=MariaDB 10.5 database server
@@ -39,9 +11,6 @@ After=network.target
 
 [Install]
 WantedBy=multi-user.target
-# we must comment it because we use mysqld as alias for mariadb
-#Alias=mysql.service
-#Alias=mysqld.service
 
 [Service]
 Type=notify


### PR DESCRIPTION
Rh-mariadb105 use an alias in systemd to mysql and mysqld. We still use an alias to mariadb with mysqld and we cannot remove the Rh-mariadb105 alias by a dropin file in /etc/systemd/system.

I think we have to overwrite the systemd service, this is what I needed with rh-mariadb103 and my module

NethServer/dev#6506