### PR TITLE
Increase the max_open_files settings

### DIFF
--- a/root/etc/systemd/system/rh-mariadb105-mariadb@nextcloud.service.d/nethserver.conf
+++ b/root/etc/systemd/system/rh-mariadb105-mariadb@nextcloud.service.d/nethserver.conf
@@ -1,0 +1,2 @@
+[Service]
+LimitNOFILE=50000


### PR DESCRIPTION
When we restart our specific mariadb 105 instance of nextcloud, we have some log traces relative to the maximum number of files.

```
May 31 17:05:33 ns7loc11 esmith::event[11596]: [INFO] service rh-mariadb105-mariadb@nextcloud restart
May 31 17:05:33 ns7loc11 systemd: Stopping MariaDB 10.5 database server...
May 31 17:05:34 ns7loc11 systemd: Stopped MariaDB 10.5 database server.
May 31 17:05:34 ns7loc11 systemd: Starting MariaDB 10.5 database server...
May 31 17:05:34 ns7loc11 scl: Database MariaDB is probably initialized in /var/opt/rh/rh-mariadb105/lib/mysql-nextcloud already, nothing is done.
May 31 17:05:34 ns7loc11 scl: If this is not the case, make sure the /var/opt/rh/rh-mariadb105/lib/mysql-nextcloud is empty before running mysql-prepare-db-dir.
May 31 17:05:34 ns7loc11 mysqld-scl-helper: 2021-05-31 17:05:34 0 [Note] /opt/rh/rh-mariadb105/root/usr/libexec/mysqld (mysqld 10.5.8-MariaDB) starting as process 12903
 ...
May 31 17:05:34 ns7loc11 mysqld-scl-helper: 2021-05-31 17:05:34 0 [Warning] Could not increase number of max_open_files to more than 1024 (request: 32184)
May 31 17:05:34 ns7loc11 mysqld-scl-helper: 2021-05-31 17:05:34 0 [Warning] Changed limits: max_open_files: 1024  max_connections: 151 (was 151)  table_cache: 421 (was 
2000)
May 31 17:05:34 ns7loc11 systemd: Started MariaDB 10.5 database server.
```

https://github.com/NethServer/dev/issues/6506